### PR TITLE
don't create a broken urn-gtk.h if xxd fails

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@ $(BIN): $(OBJS)
 $(OBJS): urn-gtk.h
 
 urn-gtk.h: urn-gtk.css
-	xxd --include urn-gtk.css > urn-gtk.h
+	xxd --include urn-gtk.css > urn-gtk.h || (rm urn-gtk.h; false)
 
 install:
 	cp $(BIN) $(BIN_DIR)


### PR DESCRIPTION
if `xxd` is not installed, or if it is broken in some way, the build will fail when creating `urn-gtk.h` but an empty `urn-gtk.h` will still be created and this step will be skipped on further attempts to build, even if `xxd` is now functional

this removes the broken `urn-gtk.h` file if `xxd` failed