### PR TITLE
Add GDK_WINDOW_TYPE_HINT_DIALOG (for tiling WMs)

### DIFF
--- a/urn-gtk.c
+++ b/urn-gtk.c
@@ -1064,7 +1064,10 @@ static void urn_app_window_class_init(UrnAppWindowClass *class) {
 }
 
 static UrnAppWindow *urn_app_window_new(UrnApp *app) {
-    return g_object_new(URN_APP_WINDOW_TYPE, "application", app, NULL);
+    UrnAppWindow *win;
+    win = g_object_new(URN_APP_WINDOW_TYPE, "application", app, NULL);
+    gtk_window_set_type_hint(GTK_WINDOW(win), GDK_WINDOW_TYPE_HINT_DIALOG);
+    return win;
 }
 
 static void urn_app_window_open(UrnAppWindow *win, const char *file) {


### PR DESCRIPTION
This changes the default behavior of urn to create the application window in floating mode (i.e., as a popup dialog) instead of tiling mode when using a tiling window manager like i3. In my opinion, the popup dialog is more suitable for streaming and should be the default because the tiled window does not obey the 'width' and 'height' settings specified in the splits JSON file. The patch should not have any visible effect on a standard compositing window manager (please confirm this before pulling). See the illustrations below.

## Before
![before](https://cloud.githubusercontent.com/assets/5674089/8386787/ae9fa7a6-1c5b-11e5-9177-1e1e26041cc2.png)

## After
![after](https://cloud.githubusercontent.com/assets/5674089/8386789/b8cc8f00-1c5b-11e5-8ba1-2e31773f8f10.png)