### PR TITLE
several minor improvements

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ COMPONENTS  = $(addprefix components/, \
               prev-segment.o best-sum.o pb.o wr.o)
 
 LIBS        = gtk+-3.0 x11 jansson
-CFLAGS      += `pkg-config --cflags $(LIBS)`
+CFLAGS      += `pkg-config --cflags $(LIBS)` -Wall -Wno-unused-parameter -std=gnu99
 LDLIBS      += `pkg-config --libs $(LIBS)`
 
 BIN_DIR     = /usr/local/bin

--- a/components/splits.c
+++ b/components/splits.c
@@ -18,7 +18,6 @@ extern UrnComponentOps urn_splits_operations;
 
 UrnComponent *urn_component_splits_new() {
     UrnSplits *self;
-    GdkRGBA color;
 
     self = malloc(sizeof(UrnSplits));
     if (!self) return NULL;
@@ -32,15 +31,6 @@ UrnComponent *urn_component_splits_new() {
     gtk_widget_show(self->split_scroller);
     gtk_widget_add_events(self->split_scroller, GDK_SCROLL_MASK);
 
-    // hide split scrollbar
-    gdk_rgba_parse(&color, "rgba(0,0,0,0)");
-    gtk_widget_override_background_color(
-        GTK_WIDGET(
-            gtk_scrolled_window_get_vscrollbar(
-                GTK_SCROLLED_WINDOW(self->split_scroller))),
-        GTK_STATE_NORMAL,
-        &color);
-    
     self->split_viewport = gtk_viewport_new(NULL, NULL);
     gtk_container_add(GTK_CONTAINER(self->split_scroller),
             self->split_viewport);
@@ -275,7 +265,7 @@ static void splits_draw(UrnComponent *self_, urn_game *game, urn_timer *timer) {
             if (time_width) {
                 width = gtk_widget_get_allocated_width(
                     self->split_times[i]);
-                gtk_widget_set_margin_left(self->split_times[i],
+                gtk_widget_set_margin_start(self->split_times[i],
                     /*WINDOW_PAD*/ 8 * 2 + (time_width - width));
             }
         }

--- a/components/title.c
+++ b/components/title.c
@@ -28,7 +28,7 @@ UrnComponent *urn_component_title_new() {
 
     self->attempt_count = gtk_label_new(NULL);
     add_class(self->attempt_count, "attempt-count");
-    gtk_widget_set_margin_left(self->attempt_count, 8);
+    gtk_widget_set_margin_start(self->attempt_count, 8);
     gtk_widget_set_valign(self->attempt_count, GTK_ALIGN_START);
     gtk_container_add(GTK_CONTAINER(self->header), self->attempt_count);
     gtk_widget_show(self->attempt_count);

--- a/urn-gtk.c
+++ b/urn-gtk.c
@@ -130,7 +130,7 @@ static gboolean urn_app_window_step(gpointer data) {
     if (win->hide_cursor && !set_cursor) {
         GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(win));
         if (gdk_window) {
-            GdkCursor* cursor = gdk_cursor_new(GDK_BLANK_CURSOR);
+            GdkCursor *cursor = gdk_cursor_new_for_display(win->display, GDK_BLANK_CURSOR);
             gdk_window_set_cursor(gdk_window, cursor);
             set_cursor = 1;
         }

--- a/urn-gtk.c
+++ b/urn-gtk.c
@@ -11,15 +11,6 @@
 #include "keybinder.h"
 #include "components/urn-component.h"
 
-// get rid of some annoying deprecation warnings
-// on the computers i compile this on
-#if GTK_CHECK_VERSION(3, 12, 0)
-#  define gtk_widget_set_margin_left            \
-    gtk_widget_set_margin_start
-#  define gtk_widget_set_margin_right           \
-    gtk_widget_set_margin_end
-#endif
-
 #define URN_APP_TYPE (urn_app_get_type ())
 #define URN_APP(obj)                            \
     (G_TYPE_CHECK_INSTANCE_CAST                 \
@@ -497,8 +488,8 @@ static void urn_app_window_init(UrnAppWindow *win) {
         if (component) {
             GtkWidget *widget = component->ops->widget(component);
             if (widget) {
-                gtk_widget_set_margin_left(widget, WINDOW_PAD);
-                gtk_widget_set_margin_right(widget, WINDOW_PAD);
+                gtk_widget_set_margin_start(widget, WINDOW_PAD);
+                gtk_widget_set_margin_end(widget, WINDOW_PAD);
                 gtk_container_add(GTK_CONTAINER(win->box),
                         component->ops->widget(component));
             }
@@ -508,8 +499,8 @@ static void urn_app_window_init(UrnAppWindow *win) {
 
     win->footer = gtk_grid_new();
     add_class(win->footer, "footer");
-    gtk_widget_set_margin_left(win->footer, WINDOW_PAD);
-    gtk_widget_set_margin_right(win->footer, WINDOW_PAD);
+    gtk_widget_set_margin_start(win->footer, WINDOW_PAD);
+    gtk_widget_set_margin_end(win->footer, WINDOW_PAD);
     gtk_container_add(GTK_CONTAINER(win->box), win->footer);
     gtk_widget_show(win->footer);
 

--- a/urn.c
+++ b/urn.c
@@ -63,7 +63,7 @@ static void urn_time_string_format(char *string,
     hours = time / (1000000LL * 60 * 60);
     minutes = (time / (1000000LL * 60)) % 60;
     seconds = (time / 1000000LL) % 60;
-    sprintf(dot_subsecs, ".%06d", time % 1000000LL);
+    sprintf(dot_subsecs, ".%06lld", time % 1000000LL);
     if (!serialized) {
         /* Show only a dot and 2 decimal places instead of all 6 */
         dot_subsecs[3] = '\0';


### PR DESCRIPTION
- fix compiler warnings regarding deprecated gdk functions
- fix one instance of a malformed sprintf modifier
  (probably wouldn't actually have caused any issues, though
  it did generate an ugly compiler warning)
- add compilation flags (to show some fairly important warnings)
- remove "hide split scrollbar" hack
  (maybe this is in error, but i tested it with and without the
  hack and it didn't seem to make a difference, as it seems like
  the background-color property is already handled in css)