### PR TITLE
When opening the choose splits dialog, open in the last used folder.

### DIFF
--- a/urn-gtk.c
+++ b/urn-gtk.c
@@ -554,7 +554,6 @@ static void open_activated(GSimpleAction *action,
     GList *windows;
     UrnAppWindow *win;
     GtkWidget *dialog;
-    struct stat st = {0};
     gint res;
 
     windows = gtk_application_get_windows(GTK_APPLICATION(app));

--- a/urn-gtk.gschema.xml
+++ b/urn-gtk.gschema.xml
@@ -56,5 +56,10 @@
       <summary>Toggle window decorations keybind</summary>
       <description>Key for toggling window decorations.</description>
     </key>
+    <key name="splits-folder" type="s">
+      <default>'~/.urn'</default>
+      <summary>Splits folder</summary>
+      <description>When choosing a splits file, file dialog starts in this folder (auto-updated to last folder you used)</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
No reason to have to navigate to the splits folder every single time you open urn.